### PR TITLE
Puppet 4 compatibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # == Class: docker::config
 #
-class docker::config {
+class docker::config inherits docker {
   file { '/etc/sysconfig/docker':
     ensure  => 'file',
     force   => true,


### PR DESCRIPTION
The variables defined in the docker class don't seem to propagate to sub-classes in the same way in puppet 4 that they do in puppet 3. This causes many issues with the templates here. Inheriting the docker class fixes this.